### PR TITLE
docs: add critical domain mismatch check to Hostinger troubleshooting

### DIFF
--- a/HOSTINGER_TROUBLESHOOTING.md
+++ b/HOSTINGER_TROUBLESHOOTING.md
@@ -2,6 +2,25 @@
 
 ## Quick Diagnostics Checklist
 
+## ⚠️ Kritischer Schnellcheck: Richtige Domain verwenden
+
+**Im Projekt ist durchgehend die Domain `sundsmessebau.de` (ohne Bindestrich) dokumentiert.**
+
+Wenn ihr stattdessen `sunds-messebau.de` (mit Bindestrich) aufruft, kann folgendes passieren:
+- ihr landet auf einer anderen (oder nicht konfigurierten) Domain,
+- SSL-Zertifikat passt nicht,
+- DNS zeigt nicht auf eure Hostinger-Instanz,
+- oder ihr seht nur eine Placeholder-/Fehlerseite.
+
+### Prüfen
+1. Hostinger → **Domains**: Ist `sundsmessebau.de` als Primary Domain hinterlegt?
+2. Hostinger → **Subdomains/Redirects**: Gibt es einen Redirect von `sunds-messebau.de` auf `https://www.sundsmessebau.de/`?
+3. Git-Deployment in Hostinger zeigt auf die gleiche Website-Instanz (gleiches `public_html`).
+
+> Empfehlung: Eine Domain als **kanonische Hauptdomain** festlegen (z. B. `www.sundsmessebau.de`) und alle Varianten per 301 dorthin leiten.
+
+---
+
 Wenn die Website auf Hostinger nicht läuft, gehe diese Checkliste durch:
 
 ### ✅ 1. Build-Verifizierung (Lokal)


### PR DESCRIPTION
### Motivation
- Dokumentieren und hervorheben der wahrscheinlichsten Fehlerursache: Das Repository und Deployment-Dokumente referenzieren die Domain `sundsmessebau.de` (ohne Bindestrich), während das gemeldete Problem die Variante `sunds-messebau.de` (mit Bindestrich) verwendet, was zu DNS/SSL/Hostinger-Instanz-Mismatch und einer Placeholder- oder Fehlerseite führen kann.

### Description
- Ergänzung einer neuen Sektion `⚠️ Kritischer Schnellcheck: Richtige Domain verwenden` in `HOSTINGER_TROUBLESHOOTING.md`, die das Domain-Mismatch-Risiko erklärt, konkrete Hostinger-Prüfungen (`Primary Domain`, Redirects, gleiche `public_html` Instanz) vorschlägt und eine Empfehlung zur Festlegung einer kanonischen Domain mit 301-Redirects gibt.

### Testing
- Die Änderung wurde geprüft als Diff und mit `git add` / `git commit` committed (Commit erfolgreich). 
- Relevante Konfigurationen und Workflows wurden per Datei-Inspektion (`.github/workflows/deploy-hostinger.yml`, `vite.config.ts`, `HOSTINGER_GIT_SETUP.md`, `README.md`) geprüft und auf Konsistenz zur Dokumentation abgeglichen (Erfolg). 
- Ein Versuch, die live-Domains per `curl` zu validieren schlug in dieser Umgebung fehl, weil ausgehende Verbindungen durch einen Proxy blockiert wurden (`403 CONNECT tunnel failed`), sodass Live-HTTP-Checks nicht erfolgreich abgeschlossen werden konnten.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e27a437e48320a0549f7dffbd3335)